### PR TITLE
Rerun 06_RFM_ADD_Comparisons with refreshed outputs

### DIFF
--- a/06_RFM_ADD_Comparisons.ipynb
+++ b/06_RFM_ADD_Comparisons.ipynb
@@ -6,10 +6,10 @@
    "id": "c24a7c8a-e9b0-4ff1-96af-e299c006ae8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-22T20:30:31.205355Z",
-     "iopub.status.busy": "2026-02-22T20:30:31.205144Z",
-     "iopub.status.idle": "2026-02-22T20:30:31.694792Z",
-     "shell.execute_reply": "2026-02-22T20:30:31.693995Z"
+     "iopub.execute_input": "2026-07-09T23:41:56.510379Z",
+     "iopub.status.busy": "2026-07-09T23:41:56.510202Z",
+     "iopub.status.idle": "2026-07-09T23:41:57.850086Z",
+     "shell.execute_reply": "2026-07-09T23:41:57.849251Z"
     }
    },
    "outputs": [
@@ -19,16 +19,16 @@
      "text": [
       "\n",
       "Results for column: thaw_offset\n",
-      "Total number of lake-years: 152082\n",
-      "Negative Values; SAR RFM Earlier than ADD: 38748 (25.48%)\n",
-      "Positive Values; SAR RFM Later than ADD: 109429 (71.95%)\n",
-      "Same Day Values: 3905 (2.57%)\n",
+      "Total number of lake-years: 150942\n",
+      "Negative Values; SAR RFM Earlier than ADD: 56082 (37.15%)\n",
+      "Positive Values; SAR RFM Later than ADD: 90604 (60.03%)\n",
+      "Same Day Values: 4256 (2.82%)\n",
       "\n",
       "Results for column: freeze_offset\n",
-      "Total number of lake-years: 152082\n",
-      "Negative Values; SAR RFM Earlier than ADD: 77057 (50.67%)\n",
-      "Positive Values; SAR RFM Later than ADD: 63210 (41.56%)\n",
-      "Same Day Values: 11815 (7.77%)\n"
+      "Total number of lake-years: 150942\n",
+      "Negative Values; SAR RFM Earlier than ADD: 116279 (77.04%)\n",
+      "Positive Values; SAR RFM Later than ADD: 32373 (21.45%)\n",
+      "Same Day Values: 2290 (1.52%)\n"
      ]
     }
    ],
@@ -66,10 +66,10 @@
    "id": "a8a382f8-b749-4b2f-b0fa-d64b38a908ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-22T20:30:31.697821Z",
-     "iopub.status.busy": "2026-02-22T20:30:31.697565Z",
-     "iopub.status.idle": "2026-02-22T20:34:30.363580Z",
-     "shell.execute_reply": "2026-02-22T20:34:30.362459Z"
+     "iopub.execute_input": "2026-07-09T23:41:57.852752Z",
+     "iopub.status.busy": "2026-07-09T23:41:57.852541Z",
+     "iopub.status.idle": "2026-07-09T23:45:07.757499Z",
+     "shell.execute_reply": "2026-07-09T23:45:07.756659Z"
     }
    },
    "outputs": [
@@ -77,64 +77,64 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Merged dataset: 152082 lake-years\n",
-      "Gap data available: 152082 thaw, 152082 freeze\n",
+      "Merged dataset: 150942 lake-years\n",
+      "Gap data available: 150942 thaw, 150942 freeze\n",
       "\n",
       "==============================\n",
       "Results for column: thaw_offset\n",
-      "Total number of lake-years: 152082\n",
+      "Total number of lake-years: 150942\n",
       "\n",
-      "Negative Values; SAR RFM Earlier than ADD: 38748 (25.48%)\n",
-      "  area_km2: {'mean': np.float64(0.27345157077867693), 'median': np.float64(0.06582548532779395), 'p5': np.float64(0.0219270747855738), 'p25': np.float64(0.0332170660616429), 'p75': np.float64(0.18733899189515182), 'p95': np.float64(1.0891989681444372)}\n",
-      "  log_area_km2: {'mean': np.float64(-1.0406411166244816), 'median': np.float64(-1.1816059308895586), 'p5': np.float64(-1.6590193021674395), 'p25': np.float64(-1.4786387297867742), 'p75': np.float64(-0.7273718289752392), 'p95': np.float64(0.03710722123807998)}\n",
-      "  circularity: {'mean': np.float64(0.3582161208206381), 'median': np.float64(0.3770662001846368), 'p5': np.float64(0.11701197076451036), 'p25': np.float64(0.2518406067261451), 'p75': np.float64(0.4703267195333392), 'p95': np.float64(0.5537192099441579)}\n",
-      "  sdi: {'mean': np.float64(1.8230662706336496), 'median': np.float64(1.6285128802224567), 'p5': np.float64(1.343863645597362), 'p25': np.float64(1.4581431904058777), 'p75': np.float64(1.9926779792623883), 'p95': np.float64(2.923377539065266)}\n",
-      "  convexity: {'mean': np.float64(0.8205539774494551), 'median': np.float64(0.8695160960955725), 'p5': np.float64(0.5257018073564327), 'p25': np.float64(0.7686569756034919), 'p75': np.float64(0.9166380726957171), 'p95': np.float64(0.9477126589170408)}\n",
-      "  latitude: {'mean': np.float64(69.99005004819246), 'median': np.float64(70.03079898427076), 'p5': np.float64(69.20621029209924), 'p25': np.float64(69.70204768276326), 'p75': np.float64(70.30774677545736), 'p95': np.float64(70.68883697992428)}\n",
+      "Negative Values; SAR RFM Earlier than ADD: 56082 (37.15%)\n",
+      "  area_km2: {'mean': np.float64(0.2716560261000721), 'median': np.float64(0.0629603219695378), 'p5': np.float64(0.0217828137233962), 'p25': np.float64(0.032045665639166), 'p75': np.float64(0.18103444565038426), 'p95': np.float64(1.0688102024491666)}\n",
+      "  log_area_km2: {'mean': np.float64(-1.0535209027970405), 'median': np.float64(-1.200933059727199), 'p5': np.float64(-1.6618860223939145), 'p25': np.float64(-1.4942307035369435), 'p75': np.float64(-0.7422387866416247), 'p95': np.float64(0.02890058951639448)}\n",
+      "  circularity: {'mean': np.float64(0.3575606991252272), 'median': np.float64(0.3759734320795181), 'p5': np.float64(0.1158340975388625), 'p25': np.float64(0.2483251381593465), 'p75': np.float64(0.4714630446924851), 'p95': np.float64(0.5545704270275256)}\n",
+      "  sdi: {'mean': np.float64(1.8264355935722607), 'median': np.float64(1.630877803631031), 'p5': np.float64(1.3428318905632943), 'p25': np.float64(1.4563849143455951), 'p75': np.float64(2.006733298347536), 'p95': np.float64(2.938202948927346)}\n",
+      "  convexity: {'mean': np.float64(0.8210970905002593), 'median': np.float64(0.8692161633898489), 'p5': np.float64(0.5326358015414252), 'p25': np.float64(0.7671278225985138), 'p75': np.float64(0.916739581030604), 'p95': np.float64(0.9476608380559016)}\n",
+      "  latitude: {'mean': np.float64(70.05293120675604), 'median': np.float64(70.10202571554771), 'p5': np.float64(69.24135569845276), 'p25': np.float64(69.76796371442524), 'p75': np.float64(70.34891953345824), 'p95': np.float64(70.74777836719647)}\n",
       "\n",
-      "Positive Values; SAR RFM Later than ADD: 109429 (71.95%)\n",
-      "  area_km2: {'mean': np.float64(0.3183356585481382), 'median': np.float64(0.0653562080367391), 'p5': np.float64(0.0219191224914624), 'p25': np.float64(0.0329295080158297), 'p75': np.float64(0.1902309377271448), 'p95': np.float64(1.1074708601796102)}\n",
-      "  log_area_km2: {'mean': np.float64(-1.0399989696908685), 'median': np.float64(-1.1847131534844126), 'p5': np.float64(-1.6591768363529973), 'p25': np.float64(-1.4824147578276148), 'p75': np.float64(-0.7207188512705786), 'p95': np.float64(0.04433230787055601)}\n",
-      "  circularity: {'mean': np.float64(0.33797191040305835), 'median': np.float64(0.3477799469829677), 'p5': np.float64(0.09767661021164116), 'p25': np.float64(0.2161742359362983), 'p75': np.float64(0.4609071916612813), 'p95': np.float64(0.5528599627640264)}\n",
-      "  sdi: {'mean': np.float64(1.912806735792785), 'median': np.float64(1.6956949685353295), 'p5': np.float64(1.3449075447253274), 'p25': np.float64(1.4729678159635555), 'p75': np.float64(2.150790124305612), 'p95': np.float64(3.1996664709857425)}\n",
-      "  convexity: {'mean': np.float64(0.812526249741739), 'median': np.float64(0.857220840952853), 'p5': np.float64(0.5400272100125639), 'p25': np.float64(0.7448631965671368), 'p75': np.float64(0.9139634956054083), 'p95': np.float64(0.947116975592846)}\n",
-      "  latitude: {'mean': np.float64(70.26545708422493), 'median': np.float64(70.28927764145014), 'p5': np.float64(69.6643906072061), 'p25': np.float64(70.05062577586092), 'p75': np.float64(70.48267028226157), 'p95': np.float64(70.83723516637377)}\n",
+      "Positive Values; SAR RFM Later than ADD: 90604 (60.03%)\n",
+      "  area_km2: {'mean': np.float64(0.3326779988971672), 'median': np.float64(0.0674098717031311), 'p5': np.float64(0.02201259485852766), 'p25': np.float64(0.0336215835927685), 'p75': np.float64(0.19588496431342434), 'p95': np.float64(1.1327118990186915)}\n",
+      "  log_area_km2: {'mean': np.float64(-1.029414226377621), 'median': np.float64(-1.1712764994251492), 'p5': np.float64(-1.6573287595222965), 'p25': np.float64(-1.4733818349356878), 'p75': np.float64(-0.7079988985668846), 'p95': np.float64(0.05411945639712918)}\n",
+      "  circularity: {'mean': np.float64(0.33675267919526175), 'median': np.float64(0.3459167972642346), 'p5': np.float64(0.0968828559934334), 'p25': np.float64(0.2148631681966058), 'p75': np.float64(0.4599847287328209), 'p95': np.float64(0.5528745273469643)}\n",
+      "  sdi: {'mean': np.float64(1.9187138906804098), 'median': np.float64(1.7002554450843377), 'p5': np.float64(1.3448898299044092), 'p25': np.float64(1.474444036400211), 'p75': np.float64(2.157342068691903), 'p95': np.float64(3.212747050794176)}\n",
+      "  convexity: {'mean': np.float64(0.8125761044386037), 'median': np.float64(0.8566289630303516), 'p5': np.float64(0.5425743068040745), 'p25': np.float64(0.7447992571729483), 'p75': np.float64(0.9137315774110628), 'p95': np.float64(0.9470395544998969)}\n",
+      "  latitude: {'mean': np.float64(70.27871319597642), 'median': np.float64(70.30200753196338), 'p5': np.float64(69.68003604523825), 'p25': np.float64(70.07641988618275), 'p75': np.float64(70.48888719935508), 'p95': np.float64(70.83252083488547)}\n",
       "\n",
-      "Same Day Values: 3905 (2.57%)\n",
-      "  area_km2: {'mean': np.float64(0.3265280558158865), 'median': np.float64(0.0636232133942687), 'p5': np.float64(0.021555783770602), 'p25': np.float64(0.0315636544822438), 'p75': np.float64(0.185734286418925), 'p95': np.float64(1.250432826452881)}\n",
-      "  log_area_km2: {'mean': np.float64(-1.0419651363979583), 'median': np.float64(-1.19638439992284), 'p5': np.float64(-1.6664361815292212), 'p25': np.float64(-1.5008127193539473), 'p75': np.float64(-0.7311079184030314), 'p95': np.float64(0.09706026927008436)}\n",
-      "  circularity: {'mean': np.float64(0.3681310982943607), 'median': np.float64(0.3900907179330654), 'p5': np.float64(0.11745115547205381), 'p25': np.float64(0.2607008586425605), 'p75': np.float64(0.4803783297020753), 'p95': np.float64(0.5661335510920682)}\n",
-      "  sdi: {'mean': np.float64(1.7931434736532221), 'median': np.float64(1.6010953334178846), 'p5': np.float64(1.3290476620173552), 'p25': np.float64(1.4428071841249026), 'p75': np.float64(1.9585234200755657), 'p95': np.float64(2.917906478683598)}\n",
-      "  convexity: {'mean': np.float64(0.8344689945032658), 'median': np.float64(0.8755972087924129), 'p5': np.float64(0.5917829994459038), 'p25': np.float64(0.7883604566727772), 'p75': np.float64(0.9191492921528838), 'p95': np.float64(0.9460128348041763)}\n",
-      "  latitude: {'mean': np.float64(70.1828348400442), 'median': np.float64(70.2188103396024), 'p5': np.float64(69.39793590699908), 'p25': np.float64(70.04805376761357), 'p75': np.float64(70.35353171136742), 'p95': np.float64(70.7579642769783)}\n",
+      "Same Day Values: 4256 (2.82%)\n",
+      "  area_km2: {'mean': np.float64(0.27202014148893866), 'median': np.float64(0.061678833953815404), 'p5': np.float64(0.021848189451653625), 'p25': np.float64(0.03241128696908377), 'p75': np.float64(0.18613738482590286), 'p95': np.float64(1.0595471515711703)}\n",
+      "  log_area_km2: {'mean': np.float64(-1.0492448911589412), 'median': np.float64(-1.209863969934299), 'p5': np.float64(-1.6605845488475202), 'p25': np.float64(-1.4893037239090294), 'p75': np.float64(-0.7301664560886096), 'p95': np.float64(0.025120092315594155)}\n",
+      "  circularity: {'mean': np.float64(0.3433064696368032), 'median': np.float64(0.3545052592868736), 'p5': np.float64(0.11036201075736198), 'p25': np.float64(0.22429229376943302), 'p75': np.float64(0.46289436024722497), 'p95': np.float64(0.5520772715883142)}\n",
+      "  sdi: {'mean': np.float64(1.875477016462698), 'median': np.float64(1.6795334536147402), 'p5': np.float64(1.3458605650945294), 'p25': np.float64(1.4698028001827637), 'p75': np.float64(2.11150854940902), 'p95': np.float64(3.0101644302122286)}\n",
+      "  convexity: {'mean': np.float64(0.8158712395441445), 'median': np.float64(0.8601665438159389), 'p5': np.float64(0.5375508903927295), 'p25': np.float64(0.750069853411306), 'p75': np.float64(0.9160371970768977), 'p95': np.float64(0.9489282958971619)}\n",
+      "  latitude: {'mean': np.float64(70.18895584049146), 'median': np.float64(70.17689125767853), 'p5': np.float64(69.60223209453004), 'p25': np.float64(69.91048117785621), 'p75': np.float64(70.42658702544531), 'p95': np.float64(70.88340972409685)}\n",
       "\n",
       "==============================\n",
       "Results for column: freeze_offset\n",
-      "Total number of lake-years: 152082\n",
+      "Total number of lake-years: 150942\n",
       "\n",
-      "Negative Values; SAR RFM Earlier than ADD: 77057 (50.67%)\n",
-      "  area_km2: {'mean': np.float64(0.30344596858957723), 'median': np.float64(0.0578067503579012), 'p5': np.float64(0.0216518581008225), 'p25': np.float64(0.0311523002415541), 'p75': np.float64(0.1610191405308128), 'p95': np.float64(0.9932733991908177)}\n",
-      "  log_area_km2: {'mean': np.float64(-1.0836408934689246), 'median': np.float64(-1.238021444070647), 'p5': np.float64(-1.6645048277952619), 'p25': np.float64(-1.5065098801338206), 'p75': np.float64(-0.7931224958139432), 'p95': np.float64(-0.0029312111730625447)}\n",
-      "  circularity: {'mean': np.float64(0.3284722699728962), 'median': np.float64(0.33301894630507), 'p5': np.float64(0.09298067240277418), 'p25': np.float64(0.2048619562506661), 'p75': np.float64(0.4527098675043945), 'p95': np.float64(0.5504560464612132)}\n",
-      "  sdi: {'mean': np.float64(1.9516504653732727), 'median': np.float64(1.7328681872641716), 'p5': np.float64(1.347841042482861), 'p25': np.float64(1.486243675816502), 'p75': np.float64(2.209374525654037), 'p95': np.float64(3.279470108878417)}\n",
-      "  convexity: {'mean': np.float64(0.8043105754795503), 'median': np.float64(0.845084881688502), 'p5': np.float64(0.5376590795464983), 'p25': np.float64(0.7318947121803472), 'p75': np.float64(0.9088717437454544), 'p95': np.float64(0.9448036556014492)}\n",
-      "  latitude: {'mean': np.float64(70.29684452442719), 'median': np.float64(70.3135243486771), 'p5': np.float64(69.69075843707904), 'p25': np.float64(70.09836887613102), 'p75': np.float64(70.50275682100008), 'p95': np.float64(70.8587198890851)}\n",
+      "Negative Values; SAR RFM Earlier than ADD: 116279 (77.04%)\n",
+      "  area_km2: {'mean': np.float64(0.30782720305821903), 'median': np.float64(0.0621281492905737), 'p5': np.float64(0.0217845700215519), 'p25': np.float64(0.0321247665263646), 'p75': np.float64(0.1788239005083751), 'p95': np.float64(1.080027350212533)}\n",
+      "  log_area_km2: {'mean': np.float64(-1.0556290819370084), 'median': np.float64(-1.2067115832106845), 'p5': np.float64(-1.6618510076405626), 'p25': np.float64(-1.4931600199775357), 'p75': np.float64(-0.7475744365176354), 'p95': np.float64(0.03343474904400422)}\n",
+      "  circularity: {'mean': np.float64(0.3395822501656034), 'median': np.float64(0.3494904354058614), 'p5': np.float64(0.0989083228182229), 'p25': np.float64(0.218319691511697), 'p75': np.float64(0.4625530836054558), 'p95': np.float64(0.554562379293962)}\n",
+      "  sdi: {'mean': np.float64(1.9066898194579704), 'median': np.float64(1.691540313756592), 'p5': np.float64(1.3428416340245108), 'p25': np.float64(1.470344866925627), 'p75': np.float64(2.1401959875261327), 'p95': np.float64(3.179681215311579)}\n",
+      "  convexity: {'mean': np.float64(0.8132612402163896), 'median': np.float64(0.8578396004592669), 'p5': np.float64(0.5432909171297301), 'p25': np.float64(0.7463896594427619), 'p75': np.float64(0.9136030149560024), 'p95': np.float64(0.9464630144885079)}\n",
+      "  latitude: {'mean': np.float64(70.28263494515616), 'median': np.float64(70.30575209509632), 'p5': np.float64(69.6843476834771), 'p25': np.float64(70.08452570176586), 'p75': np.float64(70.4902870950875), 'p95': np.float64(70.84145614628213)}\n",
       "\n",
-      "Positive Values; SAR RFM Later than ADD: 63210 (41.56%)\n",
-      "  area_km2: {'mean': np.float64(0.3130575981736234), 'median': np.float64(0.07571908098966426), 'p5': np.float64(0.022323130354701577), 'p25': np.float64(0.0358241484152113), 'p75': np.float64(0.2263767547342844), 'p95': np.float64(1.2103329744019349)}\n",
-      "  log_area_km2: {'mean': np.float64(-0.9932505451430035), 'median': np.float64(-1.1207946663277575), 'p5': np.float64(-1.651244905748468), 'p25': np.float64(-1.4458241245306271), 'p75': np.float64(-0.6451681702793722), 'p95': np.float64(0.08290485828469357)}\n",
-      "  circularity: {'mean': np.float64(0.3594154342647581), 'median': np.float64(0.378976558095332), 'p5': np.float64(0.11632077456913845), 'p25': np.float64(0.2505201591647722), 'p75': np.float64(0.4736900190435189), 'p95': np.float64(0.5555425246076973)}\n",
-      "  sdi: {'mean': np.float64(1.8215213226432612), 'median': np.float64(1.6244031628266904), 'p5': np.float64(1.3416565213426983), 'p25': np.float64(1.4529574061522144), 'p75': np.float64(1.997922604508335), 'p95': np.float64(2.9320499027705744)}\n",
-      "  convexity: {'mean': np.float64(0.824762718827012), 'median': np.float64(0.8741233535365864), 'p5': np.float64(0.5318448946489366), 'p25': np.float64(0.774092371703371), 'p75': np.float64(0.9196757410461128), 'p95': np.float64(0.9496312003673437)}\n",
-      "  latitude: {'mean': np.float64(70.05301296258004), 'median': np.float64(70.09161996986155), 'p5': np.float64(69.26798739144499), 'p25': np.float64(69.77315207765018), 'p75': np.float64(70.34308154184676), 'p95': np.float64(70.7148921699064)}\n",
+      "Positive Values; SAR RFM Later than ADD: 32373 (21.45%)\n",
+      "  area_km2: {'mean': np.float64(0.3127012254620825), 'median': np.float64(0.0790110723493627), 'p5': np.float64(0.0225201718133223), 'p25': np.float64(0.0367428812049716), 'p75': np.float64(0.2345810976247703), 'p95': np.float64(1.2003881927194056)}\n",
+      "  log_area_km2: {'mean': np.float64(-0.9831884345110502), 'median': np.float64(-1.1023120438579213), 'p5': np.float64(-1.647428300441777), 'p25': np.float64(-1.4348267913519606), 'p75': np.float64(-0.6297069859459534), 'p95': np.float64(0.0793217144571757)}\n",
+      "  circularity: {'mean': np.float64(0.3616241476208961), 'median': np.float64(0.3813205654976118), 'p5': np.float64(0.1225220517682299), 'p25': np.float64(0.2607200868279017), 'p75': np.float64(0.470176348116834), 'p95': np.float64(0.5494976747095344)}\n",
+      "  sdi: {'mean': np.float64(1.8045111363999589), 'median': np.float64(1.61940279979763), 'p5': np.float64(1.349015906384789), 'p25': np.float64(1.4583763428491647), 'p75': np.float64(1.9584511978963348), 'p95': np.float64(2.8568857283796025)}\n",
+      "  convexity: {'mean': np.float64(0.8242429302448765), 'median': np.float64(0.8730499291375629), 'p5': np.float64(0.5215290590737831), 'p25': np.float64(0.7770966549922957), 'p75': np.float64(0.9188063729773652), 'p95': np.float64(0.9500603285059958)}\n",
+      "  latitude: {'mean': np.float64(69.8815041551963), 'median': np.float64(69.89715651136422), 'p5': np.float64(69.17774957051755), 'p25': np.float64(69.6334833844501), 'p75': np.float64(70.17464818895117), 'p95': np.float64(70.46134805310899)}\n",
       "\n",
-      "Same Day Values: 11815 (7.77%)\n",
-      "  area_km2: {'mean': np.float64(0.2991908184168977), 'median': np.float64(0.0713037752976699), 'p5': np.float64(0.02199891373947793), 'p25': np.float64(0.0337452979458578), 'p75': np.float64(0.2130612871399113), 'p95': np.float64(1.2552239081411114)}\n",
-      "  log_area_km2: {'mean': np.float64(-1.0082268144204247), 'median': np.float64(-1.1468874750914813), 'p5': np.float64(-1.6575987632135576), 'p25': np.float64(-1.4717867330087173), 'p75': np.float64(-0.6714954536590927), 'p95': np.float64(0.09872109601453931)}\n",
-      "  circularity: {'mean': np.float64(0.3615658962942896), 'median': np.float64(0.379224324018947), 'p5': np.float64(0.11718501885732774), 'p25': np.float64(0.25383173824595184), 'p75': np.float64(0.4756465795329567), 'p95': np.float64(0.5605668814698378)}\n",
-      "  sdi: {'mean': np.float64(1.8139849932838188), 'median': np.float64(1.623872424837851), 'p5': np.float64(1.3356303641450014), 'p25': np.float64(1.4499659744867046), 'p75': np.float64(1.9848470177079447), 'p95': np.float64(2.9212179087901413)}\n",
-      "  convexity: {'mean': np.float64(0.8342234831106538), 'median': np.float64(0.8777166159882128), 'p5': np.float64(0.5812580780877635), 'p25': np.float64(0.7867651020830114), 'p75': np.float64(0.9192279405575966), 'p95': np.float64(0.9470462429573521)}\n",
-      "  latitude: {'mean': np.float64(70.26679938247254), 'median': np.float64(70.31998751257886), 'p5': np.float64(69.66599221994488), 'p25': np.float64(70.11622667351668), 'p75': np.float64(70.47952047435459), 'p95': np.float64(70.74889515832156)}\n",
+      "Same Day Values: 2290 (1.52%)\n",
+      "  area_km2: {'mean': np.float64(0.26976955183818846), 'median': np.float64(0.07949087113063516), 'p5': np.float64(0.022879636449354274), 'p25': np.float64(0.0388792042458444), 'p75': np.float64(0.2331795274438099), 'p95': np.float64(1.0574341232747682)}\n",
+      "  log_area_km2: {'mean': np.float64(-0.979012613613285), 'median': np.float64(-1.0996827452002949), 'p5': np.float64(-1.6405509768450315), 'p25': np.float64(-1.410282632531449), 'p75': np.float64(-0.6323098156898362), 'p95': np.float64(0.024249234787732478)}\n",
+      "  circularity: {'mean': np.float64(0.3632437602555696), 'median': np.float64(0.3834456990336481), 'p5': np.float64(0.1199441293872555), 'p25': np.float64(0.25364980840072276), 'p75': np.float64(0.47566223917442985), 'p95': np.float64(0.5574596339876776)}\n",
+      "  sdi: {'mean': np.float64(1.8034584963159288), 'median': np.float64(1.614909307310836), 'p5': np.float64(1.3393477134931397), 'p25': np.float64(1.4499421073852663), 'p75': np.float64(1.9855587042913276), 'p95': np.float64(2.8874250325231583)}\n",
+      "  convexity: {'mean': np.float64(0.8276595019876584), 'median': np.float64(0.8780847892754736), 'p5': np.float64(0.5465004845163799), 'p25': np.float64(0.7800992714018766), 'p75': np.float64(0.9199787460187588), 'p95': np.float64(0.9501207873679646)}\n",
+      "  latitude: {'mean': np.float64(69.99859021776834), 'median': np.float64(70.00052016320971), 'p5': np.float64(69.34904204056525), 'p25': np.float64(69.75414403598445), 'p75': np.float64(70.25830838193471), 'p95': np.float64(70.52639704630056)}\n",
       "\n",
       "\n",
       "============================================================\n",
@@ -142,17 +142,17 @@
       "============================================================\n",
       "\n",
       "\n",
-      "### Within-column tests for: thaw_offset (ALL DATA) ###\n"
+      "### Within-column tests for: thaw_offset (ALL DATA) ###\n",
+      "  Negative: 56082, Positive: 90604, Zero: 4256\n",
+      "\n",
+      "--- area_km2 ---\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Negative: 38748, Positive: 109429, Zero: 3905\n",
-      "\n",
-      "--- area_km2 ---\n",
-      "Kruskal-Wallis H = 2.3785, p = 0.304453\n"
+      "Kruskal-Wallis H = 94.6032, p = 0.000000\n"
      ]
     },
     {
@@ -160,8 +160,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 2123971644.0000, p = 0.590454\n",
-      "  Cliff's Delta = 0.0018\n"
+      "  Mann-Whitney U = 2465098686.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0297\n"
      ]
     },
     {
@@ -169,8 +169,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 76777145.0000, p = 0.126147\n",
-      "  Cliff's Delta = 0.0148\n"
+      "  Mann-Whitney U = 118931363.0000, p = 0.707449\n",
+      "  Cliff's Delta = -0.0034\n"
      ]
     },
     {
@@ -178,11 +178,11 @@
      "output_type": "stream",
      "text": [
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 216452913.5000, p = 0.164475\n",
-      "  Cliff's Delta = 0.0131\n",
+      "  Mann-Whitney U = 197873462.5000, p = 0.003698\n",
+      "  Cliff's Delta = 0.0263\n",
       "\n",
       "--- log_area_km2 ---\n",
-      "Kruskal-Wallis H = 2.3785, p = 0.304453\n"
+      "Kruskal-Wallis H = 94.6032, p = 0.000000\n"
      ]
     },
     {
@@ -190,8 +190,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 2123971644.0000, p = 0.590454\n",
-      "  Cliff's Delta = 0.0018\n"
+      "  Mann-Whitney U = 2465098686.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0297\n"
      ]
     },
     {
@@ -199,8 +199,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 76777145.0000, p = 0.126147\n",
-      "  Cliff's Delta = 0.0148\n"
+      "  Mann-Whitney U = 118931363.0000, p = 0.707449\n",
+      "  Cliff's Delta = -0.0034\n"
      ]
     },
     {
@@ -208,11 +208,11 @@
      "output_type": "stream",
      "text": [
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 216452913.5000, p = 0.164475\n",
-      "  Cliff's Delta = 0.0131\n",
+      "  Mann-Whitney U = 197873462.5000, p = 0.003698\n",
+      "  Cliff's Delta = 0.0263\n",
       "\n",
       "--- circularity ---\n",
-      "Kruskal-Wallis H = 641.2559, p = 0.000000\n"
+      "Kruskal-Wallis H = 687.2349, p = 0.000000\n"
      ]
     },
     {
@@ -220,8 +220,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 2286783750.0000, p = 0.000000\n",
-      "  Cliff's Delta = 0.0786\n"
+      "  Mann-Whitney U = 2747032605.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0812\n"
      ]
     },
     {
@@ -229,8 +229,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 72411774.0000, p = 0.000010\n",
-      "  Cliff's Delta = -0.0429\n"
+      "  Mann-Whitney U = 126308666.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0584\n"
      ]
     },
     {
@@ -238,11 +238,11 @@
      "output_type": "stream",
      "text": [
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 188313359.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1186\n",
+      "  Mann-Whitney U = 188126179.5000, p = 0.007362\n",
+      "  Cliff's Delta = -0.0243\n",
       "\n",
       "--- sdi ---\n",
-      "Kruskal-Wallis H = 641.2559, p = 0.000000\n"
+      "Kruskal-Wallis H = 687.2349, p = 0.000000\n"
      ]
     },
     {
@@ -250,8 +250,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 1953371142.0000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0786\n"
+      "  Mann-Whitney U = 2334220923.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0812\n"
      ]
     },
     {
@@ -259,8 +259,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 78899166.0000, p = 0.000010\n",
-      "  Cliff's Delta = 0.0429\n"
+      "  Mann-Whitney U = 112376326.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0584\n"
      ]
     },
     {
@@ -268,11 +268,11 @@
      "output_type": "stream",
      "text": [
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 239006885.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.1186\n",
+      "  Mann-Whitney U = 197484444.5000, p = 0.007362\n",
+      "  Cliff's Delta = 0.0243\n",
       "\n",
       "--- convexity ---\n",
-      "Kruskal-Wallis H = 276.9311, p = 0.000000\n"
+      "Kruskal-Wallis H = 248.2294, p = 0.000000\n"
      ]
     },
     {
@@ -280,7 +280,7 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 2223769685.0000, p = 0.000000\n",
+      "  Mann-Whitney U = 2664840852.0000, p = 0.000000\n",
       "  Cliff's Delta = 0.0489\n"
      ]
     },
@@ -289,8 +289,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 72475814.0000, p = 0.000015\n",
-      "  Cliff's Delta = -0.0420\n"
+      "  Mann-Whitney U = 122988502.0000, p = 0.000874\n",
+      "  Cliff's Delta = 0.0306\n"
      ]
     },
     {
@@ -298,11 +298,11 @@
      "output_type": "stream",
      "text": [
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 193971388.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0921\n",
+      "  Mann-Whitney U = 189392115.5000, p = 0.050590\n",
+      "  Cliff's Delta = -0.0177\n",
       "\n",
       "--- latitude ---\n",
-      "Kruskal-Wallis H = 11718.9757, p = 0.000000\n"
+      "Kruskal-Wallis H = 10038.7113, p = 0.000000\n"
      ]
     },
     {
@@ -310,8 +310,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 1339269489.0000, p = 0.000000\n",
-      "  Cliff's Delta = -0.3683\n"
+      "  Mann-Whitney U = 1751873975.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.3105\n"
      ]
     },
     {
@@ -319,8 +319,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 55310400.0000, p = 0.000000\n",
-      "  Cliff's Delta = -0.2689\n"
+      "  Mann-Whitney U = 100766710.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.1557\n"
      ]
     },
     {
@@ -328,15 +328,15 @@
      "output_type": "stream",
      "text": [
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 243217283.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.1383\n",
+      "  Mann-Whitney U = 223168667.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.1575\n",
       "\n",
       "\n",
       "### Within-column tests for: freeze_offset (ALL DATA) ###\n",
-      "  Negative: 77057, Positive: 63210, Zero: 11815\n",
+      "  Negative: 116279, Positive: 32373, Zero: 2290\n",
       "\n",
       "--- area_km2 ---\n",
-      "Kruskal-Wallis H = 1204.8580, p = 0.000000\n"
+      "Kruskal-Wallis H = 665.4849, p = 0.000000\n"
      ]
     },
     {
@@ -344,8 +344,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 2177273081.0000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1060\n"
+      "  Mann-Whitney U = 1712189059.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0903\n"
      ]
     },
     {
@@ -353,20 +353,14 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 418397669.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0809\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Mann-Whitney U = 119536598.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.1022\n",
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 382195265.5000, p = 0.000048\n",
-      "  Cliff's Delta = 0.0235\n",
+      "  Mann-Whitney U = 36671522.0000, p = 0.392670\n",
+      "  Cliff's Delta = -0.0107\n",
       "\n",
       "--- log_area_km2 ---\n",
-      "Kruskal-Wallis H = 1204.8580, p = 0.000000\n"
+      "Kruskal-Wallis H = 665.4849, p = 0.000000\n"
      ]
     },
     {
@@ -374,8 +368,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 2177273081.0000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1060\n"
+      "  Mann-Whitney U = 1712189059.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0903\n"
      ]
     },
     {
@@ -383,20 +377,14 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 418397669.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0809\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Mann-Whitney U = 119536598.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.1022\n",
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 382195265.5000, p = 0.000048\n",
-      "  Cliff's Delta = 0.0235\n",
+      "  Mann-Whitney U = 36671522.0000, p = 0.392670\n",
+      "  Cliff's Delta = -0.0107\n",
       "\n",
       "--- circularity ---\n",
-      "Kruskal-Wallis H = 1746.8378, p = 0.000000\n"
+      "Kruskal-Wallis H = 590.5714, p = 0.000000\n"
      ]
     },
     {
@@ -404,8 +392,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 2137207359.0000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1224\n"
+      "  Mann-Whitney U = 1721474644.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0854\n"
      ]
     },
     {
@@ -413,20 +401,14 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 395839942.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1304\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Mann-Whitney U = 120831170.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0924\n",
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 370342826.5000, p = 0.155360\n",
-      "  Cliff's Delta = -0.0082\n",
+      "  Mann-Whitney U = 36746145.0000, p = 0.487977\n",
+      "  Cliff's Delta = -0.0087\n",
       "\n",
       "--- sdi ---\n",
-      "Kruskal-Wallis H = 1746.8378, p = 0.000000\n"
+      "Kruskal-Wallis H = 590.5714, p = 0.000000\n"
      ]
     },
     {
@@ -434,8 +416,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 2733565611.0000, p = 0.000000\n",
-      "  Cliff's Delta = 0.1224\n"
+      "  Mann-Whitney U = 2042825423.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0854\n"
      ]
     },
     {
@@ -443,20 +425,14 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 514588512.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.1304\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Mann-Whitney U = 145447740.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0924\n",
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 376483323.5000, p = 0.155360\n",
-      "  Cliff's Delta = 0.0082\n",
+      "  Mann-Whitney U = 37388025.0000, p = 0.487977\n",
+      "  Cliff's Delta = 0.0087\n",
       "\n",
       "--- convexity ---\n",
-      "Kruskal-Wallis H = 1776.9451, p = 0.000000\n"
+      "Kruskal-Wallis H = 420.6088, p = 0.000000\n"
      ]
     },
     {
@@ -464,8 +440,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 2141044622.0000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1209\n"
+      "  Mann-Whitney U = 1747673817.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0714\n"
      ]
     },
     {
@@ -473,20 +449,14 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 389935499.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1434\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Mann-Whitney U = 121801056.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0852\n",
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 366989026.5000, p = 0.002950\n",
-      "  Cliff's Delta = -0.0172\n",
+      "  Mann-Whitney U = 36534353.0000, p = 0.249650\n",
+      "  Cliff's Delta = -0.0144\n",
       "\n",
       "--- latitude ---\n",
-      "Kruskal-Wallis H = 12882.7524, p = 0.000000\n"
+      "Kruskal-Wallis H = 24310.8950, p = 0.000000\n"
      ]
     },
     {
@@ -494,8 +464,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 3270946201.0000, p = 0.000000\n",
-      "  Cliff's Delta = 0.3431\n"
+      "  Mann-Whitney U = 2930716642.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.5571\n"
      ]
     },
     {
@@ -503,17 +473,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Zero:\n",
-      "  Mann-Whitney U = 467490474.5000, p = 0.000002\n",
-      "  Cliff's Delta = 0.0270\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Mann-Whitney U = 192567079.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.4464\n",
       "Positive vs Zero:\n",
-      "  Mann-Whitney U = 251882036.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.3255\n",
+      "  Mann-Whitney U = 31056149.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.1622\n",
       "\n",
       "\n",
       "### Between thaw_offset and freeze_offset comparisons (ALL DATA) ###\n",
@@ -525,21 +489,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=38748, freeze n=77057):\n",
-      "  Mann-Whitney U = 1570915743.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.0523\n"
+      "Negative group (thaw n=56082, freeze n=116279):\n",
+      "  Mann-Whitney U = 3270012190.0000, p = 0.329737\n",
+      "  Cliff's Delta = 0.0029\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=109429, freeze n=63210):\n",
-      "  Mann-Whitney U = 3266150658.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0556\n",
-      "Zero group (thaw n=3905, freeze n=11815):\n",
-      "  Mann-Whitney U = 22061196.0000, p = 0.000042\n",
-      "  Cliff's Delta = -0.0437\n",
+      "Positive group (thaw n=90604, freeze n=32373):\n",
+      "  Mann-Whitney U = 1381774407.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0578\n",
+      "Zero group (thaw n=4256, freeze n=2290):\n",
+      "  Mann-Whitney U = 4408361.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0954\n",
       "\n",
       "--- log_area_km2 ---\n"
      ]
@@ -548,21 +512,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=38748, freeze n=77057):\n",
-      "  Mann-Whitney U = 1570915743.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.0523\n"
+      "Negative group (thaw n=56082, freeze n=116279):\n",
+      "  Mann-Whitney U = 3270012190.0000, p = 0.329737\n",
+      "  Cliff's Delta = 0.0029\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=109429, freeze n=63210):\n",
-      "  Mann-Whitney U = 3266150658.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0556\n",
-      "Zero group (thaw n=3905, freeze n=11815):\n",
-      "  Mann-Whitney U = 22061196.0000, p = 0.000042\n",
-      "  Cliff's Delta = -0.0437\n",
+      "Positive group (thaw n=90604, freeze n=32373):\n",
+      "  Mann-Whitney U = 1381774407.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0578\n",
+      "Zero group (thaw n=4256, freeze n=2290):\n",
+      "  Mann-Whitney U = 4408361.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0954\n",
       "\n",
       "--- circularity ---\n"
      ]
@@ -571,21 +535,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=38748, freeze n=77057):\n",
-      "  Mann-Whitney U = 1667943435.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.1172\n"
+      "Negative group (thaw n=56082, freeze n=116279):\n",
+      "  Mann-Whitney U = 3488601669.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0699\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=109429, freeze n=63210):\n",
-      "  Mann-Whitney U = 3167139094.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0842\n",
-      "Zero group (thaw n=3905, freeze n=11815):\n",
-      "  Mann-Whitney U = 23708749.0000, p = 0.009241\n",
-      "  Cliff's Delta = 0.0277\n",
+      "Positive group (thaw n=90604, freeze n=32373):\n",
+      "  Mann-Whitney U = 1324496634.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0969\n",
+      "Zero group (thaw n=4256, freeze n=2290):\n",
+      "  Mann-Whitney U = 4476155.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0815\n",
       "\n",
       "--- sdi ---\n"
      ]
@@ -594,21 +558,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=38748, freeze n=77057):\n",
-      "  Mann-Whitney U = 1317861200.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1172\n"
+      "Negative group (thaw n=56082, freeze n=116279):\n",
+      "  Mann-Whitney U = 3032557209.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0699\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=109429, freeze n=63210):\n",
-      "  Mann-Whitney U = 3749867995.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.0842\n",
-      "Zero group (thaw n=3905, freeze n=11815):\n",
-      "  Mann-Whitney U = 22428826.0000, p = 0.009241\n",
-      "  Cliff's Delta = -0.0277\n",
+      "Positive group (thaw n=90604, freeze n=32373):\n",
+      "  Mann-Whitney U = 1608626657.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0969\n",
+      "Zero group (thaw n=4256, freeze n=2290):\n",
+      "  Mann-Whitney U = 5270084.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0815\n",
       "\n",
       "--- convexity ---\n"
      ]
@@ -617,21 +581,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=38748, freeze n=77057):\n",
-      "  Mann-Whitney U = 1636394316.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.0961\n"
+      "Negative group (thaw n=56082, freeze n=116279):\n",
+      "  Mann-Whitney U = 3413703520.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0470\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=109429, freeze n=63210):\n",
-      "  Mann-Whitney U = 3201517454.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0743\n",
-      "Zero group (thaw n=3905, freeze n=11815):\n",
-      "  Mann-Whitney U = 22993379.0000, p = 0.759057\n",
-      "  Cliff's Delta = -0.0033\n",
+      "Positive group (thaw n=90604, freeze n=32373):\n",
+      "  Mann-Whitney U = 1359128600.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0733\n",
+      "Zero group (thaw n=4256, freeze n=2290):\n",
+      "  Mann-Whitney U = 4539682.5000, p = 0.000005\n",
+      "  Cliff's Delta = -0.0684\n",
       "\n",
       "--- latitude ---\n"
      ]
@@ -640,21 +604,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=38748, freeze n=77057):\n",
-      "  Mann-Whitney U = 879447507.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.4109\n"
+      "Negative group (thaw n=56082, freeze n=116279):\n",
+      "  Mann-Whitney U = 2228869631.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.3164\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=109429, freeze n=63210):\n",
-      "  Mann-Whitney U = 4489177329.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.2980\n",
-      "Zero group (thaw n=3905, freeze n=11815):\n",
-      "  Mann-Whitney U = 18882306.0000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1815\n",
+      "Positive group (thaw n=90604, freeze n=32373):\n",
+      "  Mann-Whitney U = 2275636439.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.5517\n",
+      "Zero group (thaw n=4256, freeze n=2290):\n",
+      "  Mann-Whitney U = 6177714.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.2677\n",
       "\n",
       "\n",
       "\n",
@@ -662,9 +626,9 @@
       "# FILTERED SUBSET: |offset| > 2 * per-detection gap (beyond 2 revisits)\n",
       "######################################################################\n",
       "\n",
-      "thaw_offset: 57574 of 152082 lake-years beyond 2 revisits (37.9%)\n",
+      "thaw_offset: 26707 of 150942 lake-years beyond 2 revisits (17.7%)\n",
       "\n",
-      "freeze_offset: 51335 of 152082 lake-years beyond 2 revisits (33.8%)\n",
+      "freeze_offset: 38359 of 150942 lake-years beyond 2 revisits (25.4%)\n",
       "\n",
       "\n",
       "============================================================\n",
@@ -673,10 +637,10 @@
       "\n",
       "\n",
       "### Within-column tests for: thaw_offset (|thaw_offset| > 2*gap) ###\n",
-      "  Negative: 12170, Positive: 45404, Zero: 0\n",
+      "  Negative: 8633, Positive: 18074, Zero: 0\n",
       "\n",
       "--- area_km2 ---\n",
-      "Kruskal-Wallis H = 47.1589, p = 0.000000\n"
+      "Kruskal-Wallis H = 54.8282, p = 0.000000\n"
      ]
     },
     {
@@ -684,11 +648,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 265101825.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0405\n",
+      "  Mann-Whitney U = 73652871.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0559\n",
       "\n",
       "--- log_area_km2 ---\n",
-      "Kruskal-Wallis H = 47.1589, p = 0.000000\n"
+      "Kruskal-Wallis H = 54.8282, p = 0.000000\n"
      ]
     },
     {
@@ -696,11 +660,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 265101825.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0405\n",
+      "  Mann-Whitney U = 73652871.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0559\n",
       "\n",
       "--- circularity ---\n",
-      "Kruskal-Wallis H = 522.9388, p = 0.000000\n"
+      "Kruskal-Wallis H = 468.7014, p = 0.000000\n"
      ]
     },
     {
@@ -708,11 +672,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 313517721.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.1348\n",
+      "  Mann-Whitney U = 90774526.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.1635\n",
       "\n",
       "--- sdi ---\n",
-      "Kruskal-Wallis H = 522.9388, p = 0.000000\n"
+      "Kruskal-Wallis H = 468.7014, p = 0.000000\n"
      ]
     },
     {
@@ -720,11 +684,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 239048958.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1348\n",
+      "  Mann-Whitney U = 65258316.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.1635\n",
       "\n",
       "--- convexity ---\n",
-      "Kruskal-Wallis H = 200.1773, p = 0.000000\n"
+      "Kruskal-Wallis H = 155.9483, p = 0.000000\n"
      ]
     },
     {
@@ -732,11 +696,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 299320352.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.0834\n",
+      "  Mann-Whitney U = 85375584.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0943\n",
       "\n",
       "--- latitude ---\n",
-      "Kruskal-Wallis H = 7253.0989, p = 0.000000\n"
+      "Kruskal-Wallis H = 6418.0172, p = 0.000000\n"
      ]
     },
     {
@@ -744,15 +708,15 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 137613984.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.5019\n",
+      "  Mann-Whitney U = 30805931.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.6051\n",
       "\n",
       "\n",
       "### Within-column tests for: freeze_offset (|freeze_offset| > 2*gap) ###\n",
-      "  Negative: 32566, Positive: 18769, Zero: 0\n",
+      "  Negative: 30244, Positive: 8115, Zero: 0\n",
       "\n",
       "--- area_km2 ---\n",
-      "Kruskal-Wallis H = 511.8579, p = 0.000000\n"
+      "Kruskal-Wallis H = 109.0781, p = 0.000000\n"
      ]
     },
     {
@@ -760,11 +724,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 269031063.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1197\n",
+      "  Mann-Whitney U = 113464187.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0754\n",
       "\n",
       "--- log_area_km2 ---\n",
-      "Kruskal-Wallis H = 511.8579, p = 0.000000\n"
+      "Kruskal-Wallis H = 109.0781, p = 0.000000\n"
      ]
     },
     {
@@ -772,11 +736,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 269031063.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1197\n",
+      "  Mann-Whitney U = 113464187.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0754\n",
       "\n",
       "--- circularity ---\n",
-      "Kruskal-Wallis H = 1050.0246, p = 0.000000\n"
+      "Kruskal-Wallis H = 478.2643, p = 0.000000\n"
      ]
     },
     {
@@ -784,11 +748,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 253216637.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1715\n",
+      "  Mann-Whitney U = 103344276.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.1579\n",
       "\n",
       "--- sdi ---\n",
-      "Kruskal-Wallis H = 1050.0246, p = 0.000000\n"
+      "Kruskal-Wallis H = 478.2643, p = 0.000000\n"
      ]
     },
     {
@@ -796,11 +760,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 358014616.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.1715\n",
+      "  Mann-Whitney U = 142085783.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.1579\n",
       "\n",
       "--- convexity ---\n",
-      "Kruskal-Wallis H = 695.6437, p = 0.000000\n"
+      "Kruskal-Wallis H = 243.4342, p = 0.000000\n"
      ]
     },
     {
@@ -808,11 +772,11 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 262965865.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.1396\n",
+      "  Mann-Whitney U = 108895180.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.1126\n",
       "\n",
       "--- latitude ---\n",
-      "Kruskal-Wallis H = 13979.4420, p = 0.000000\n"
+      "Kruskal-Wallis H = 9269.9252, p = 0.000000\n"
      ]
     },
     {
@@ -820,8 +784,8 @@
      "output_type": "stream",
      "text": [
       "Negative vs Positive:\n",
-      "  Mann-Whitney U = 496806908.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.6256\n",
+      "  Mann-Whitney U = 207995712.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.6949\n",
       "\n",
       "\n",
       "============================================================\n",
@@ -838,18 +802,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=12170, freeze n=32566):\n",
-      "  Mann-Whitney U = 214751884.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.0837\n"
+      "Negative group (thaw n=8633, freeze n=30244):\n",
+      "  Mann-Whitney U = 143964849.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.1028\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=45404, freeze n=18769):\n",
-      "  Mann-Whitney U = 428108473.5000, p = 0.345316\n",
-      "  Cliff's Delta = 0.0047\n",
+      "Positive group (thaw n=18074, freeze n=8115):\n",
+      "  Mann-Whitney U = 79537011.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0846\n",
       "\n",
       "--- log_area_km2 ---\n"
      ]
@@ -858,18 +822,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=12170, freeze n=32566):\n",
-      "  Mann-Whitney U = 214751884.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.0837\n"
+      "Negative group (thaw n=8633, freeze n=30244):\n",
+      "  Mann-Whitney U = 143964849.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.1028\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=45404, freeze n=18769):\n",
-      "  Mann-Whitney U = 428108473.5000, p = 0.345316\n",
-      "  Cliff's Delta = 0.0047\n",
+      "Positive group (thaw n=18074, freeze n=8115):\n",
+      "  Mann-Whitney U = 79537011.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.0846\n",
       "\n",
       "--- circularity ---\n"
      ]
@@ -878,18 +842,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=12170, freeze n=32566):\n",
-      "  Mann-Whitney U = 239555939.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.2089\n"
+      "Negative group (thaw n=8633, freeze n=30244):\n",
+      "  Mann-Whitney U = 154465062.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.1832\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=45404, freeze n=18769):\n",
-      "  Mann-Whitney U = 385149474.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0961\n",
+      "Positive group (thaw n=18074, freeze n=8115):\n",
+      "  Mann-Whitney U = 63298371.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.1369\n",
       "\n",
       "--- sdi ---\n"
      ]
@@ -898,18 +862,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=12170, freeze n=32566):\n",
-      "  Mann-Whitney U = 156772280.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.2089\n"
+      "Negative group (thaw n=8633, freeze n=30244):\n",
+      "  Mann-Whitney U = 106631390.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.1832\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=45404, freeze n=18769):\n",
-      "  Mann-Whitney U = 467038201.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.0961\n",
+      "Positive group (thaw n=18074, freeze n=8115):\n",
+      "  Mann-Whitney U = 83372138.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.1369\n",
       "\n",
       "--- convexity ---\n"
      ]
@@ -918,18 +882,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=12170, freeze n=32566):\n",
-      "  Mann-Whitney U = 233698944.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.1793\n"
+      "Negative group (thaw n=8633, freeze n=30244):\n",
+      "  Mann-Whitney U = 150006874.0000, p = 0.000000\n",
+      "  Cliff's Delta = 0.1491\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=45404, freeze n=18769):\n",
-      "  Mann-Whitney U = 407624396.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.0433\n",
+      "Positive group (thaw n=18074, freeze n=8115):\n",
+      "  Mann-Whitney U = 69272696.5000, p = 0.000000\n",
+      "  Cliff's Delta = -0.0554\n",
       "\n",
       "--- latitude ---\n"
      ]
@@ -938,18 +902,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Negative group (thaw n=12170, freeze n=32566):\n",
-      "  Mann-Whitney U = 101715808.5000, p = 0.000000\n",
-      "  Cliff's Delta = -0.4867\n"
+      "Negative group (thaw n=8633, freeze n=30244):\n",
+      "  Mann-Whitney U = 54941694.0000, p = 0.000000\n",
+      "  Cliff's Delta = -0.5791\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Positive group (thaw n=45404, freeze n=18769):\n",
-      "  Mann-Whitney U = 701954111.5000, p = 0.000000\n",
-      "  Cliff's Delta = 0.6474\n"
+      "Positive group (thaw n=18074, freeze n=8115):\n",
+      "  Mann-Whitney U = 125928823.5000, p = 0.000000\n",
+      "  Cliff's Delta = 0.7172\n"
      ]
     }
    ],


### PR DESCRIPTION
Regenerates the outputs of `06_RFM_ADD_Comparisons.ipynb`, which had not been re-run since the transition-based phenology / Figure 6 changes.

- Executed top-to-bottom on the research instance (`gee` kernel) via nbconvert; exit 0, no cell errors.
- Only cell outputs changed (numbers + figures); no code edits.
- Headline outputs: 150,942 lake-years; thaw offset 37.15% earlier / 60.03% later / 2.82% same-day; freeze offset 77.04% earlier / 21.45% later / 1.52% same-day.

Please confirm these match the numbers added to the manuscript text before merging.

Closes #6
