### PR TITLE
Add Cesar Lopez ORCID to Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,7 +11,8 @@
     },
     {
       "name": "Lopez, Cesar G.",
-      "affiliation": "Department of Earth, Environmental, and Planetary Sciences, Washington University in St. Louis, St. Louis, MO 63130, USA"
+      "affiliation": "Department of Earth, Environmental, and Planetary Sciences, Washington University in St. Louis, St. Louis, MO 63130, USA",
+      "orcid": "0009-0005-9215-8861"
     },
     {
       "name": "Melara-Valle, Jennifer",


### PR DESCRIPTION
Adds Cesar G. Lopez's ORCID (0009-0005-9215-8861) to the .zenodo.json creators list. No release cut — metadata staged for the next version archive.