### PR TITLE
Add Alexander Nguyen ORCID to Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -7,7 +7,8 @@
   "creators": [
     {
       "name": "Nguyen, Alexander L.",
-      "affiliation": "Department of Earth, Environmental, and Planetary Sciences, Washington University in St. Louis, St. Louis, MO 63130, USA"
+      "affiliation": "Department of Earth, Environmental, and Planetary Sciences, Washington University in St. Louis, St. Louis, MO 63130, USA",
+      "orcid": "0000-0001-8584-1287"
     },
     {
       "name": "Lopez, Cesar G.",


### PR DESCRIPTION
Adds Alexander L. Nguyen's ORCID (0000-0001-8584-1287) to the .zenodo.json creators list. No release cut.