### PR TITLE
Load bedfast/floating baseline data from the Arctic Data Center

### DIFF
--- a/BedfastFloatingAnalysis/BedfastFloatingIceAnalysis.ipynb
+++ b/BedfastFloatingAnalysis/BedfastFloatingIceAnalysis.ipynb
@@ -6,10 +6,10 @@
    "id": "01618784-1efa-460b-b7b9-ae5e989ae86e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T18:45:42.331957Z",
-     "iopub.status.busy": "2026-07-10T18:45:42.331612Z",
-     "iopub.status.idle": "2026-07-10T18:45:43.487993Z",
-     "shell.execute_reply": "2026-07-10T18:45:43.486606Z"
+     "iopub.execute_input": "2026-07-11T00:38:33.654508Z",
+     "iopub.status.busy": "2026-07-11T00:38:33.654094Z",
+     "iopub.status.idle": "2026-07-11T00:38:34.970712Z",
+     "shell.execute_reply": "2026-07-11T00:38:34.969695Z"
     }
    },
    "outputs": [],
@@ -29,21 +29,45 @@
    "id": "522041e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T18:45:43.492456Z",
-     "iopub.status.busy": "2026-07-10T18:45:43.491884Z",
-     "iopub.status.idle": "2026-07-10T18:45:48.741075Z",
-     "shell.execute_reply": "2026-07-10T18:45:48.739744Z"
+     "iopub.execute_input": "2026-07-11T00:38:34.975221Z",
+     "iopub.status.busy": "2026-07-11T00:38:34.974676Z",
+     "iopub.status.idle": "2026-07-11T00:38:55.155233Z",
+     "shell.execute_reply": "2026-07-11T00:38:55.154111Z"
     }
    },
    "outputs": [],
    "source": [
-    "# Fetch bedfast/floating ice-regime baseline data from GCS (gitignored locally)\n",
-    "import os, subprocess\n",
-    "_BASELINE_GCS = \"gs://wustl-eeps-geospatial/thermokarst_lakes/bedfast_baseline\"\n",
+    "# Fetch third-party ice-regime baseline data from the Arctic Data Center (both CC0).\n",
+    "# Engram (2018), doi:10.18739/A2CJ87K8H  -- bedfast/floating regime shapefiles.\n",
+    "# Bergstedt & Jones (2025), doi:10.18739/A25M6288G  -- integrated classification.\n",
+    "# Cached locally (gitignored); re-runs are offline after the first fetch.\n",
+    "import os, io, zipfile, urllib.request\n",
+    "\n",
+    "_ADC = \"https://cn.dataone.org/cn/v2/resolve/\"\n",
+    "_ENGRAM = {\n",
+    "    \"Barrow\":    \"urn:uuid:13239376-6a7c-449b-8f54-aac28119f5da\",\n",
+    "    \"FishCreek\": \"urn:uuid:3e161819-ab4b-4a92-92e4-23d8c0b9cccf\",\n",
+    "    \"Inigok\":    \"urn:uuid:6a48ca92-fa78-4f1a-a226-fc570fa6e9d6\",\n",
+    "    \"Kuparuk\":   \"urn:uuid:a24db774-9ec3-4311-afd6-4994979502a3\",\n",
+    "    \"Teshekpuk\": \"urn:uuid:12dce174-f848-4046-9ea9-c2aa2c6ff482\",\n",
+    "    \"Umiat\":     \"urn:uuid:b0ee5508-a18e-46d6-a8f2-629493f1ee5e\",\n",
+    "}\n",
+    "os.makedirs(\"engram\", exist_ok=True)\n",
+    "for site, pid in _ENGRAM.items():\n",
+    "    if any(f.startswith(site) and f.endswith(\".shp\") for f in os.listdir(\"engram\")):\n",
+    "        continue\n",
+    "    with urllib.request.urlopen(_ADC + pid) as resp:\n",
+    "        payload = resp.read()\n",
+    "    with zipfile.ZipFile(io.BytesIO(payload)) as zf:\n",
+    "        for member in zf.namelist():\n",
+    "            fname = os.path.basename(member)\n",
+    "            if fname:  # flatten any internal directories\n",
+    "                with zf.open(member) as src, open(os.path.join(\"engram\", fname), \"wb\") as dst:\n",
+    "                    dst.write(src.read())\n",
+    "\n",
+    "_BERGSTEDT = \"urn:uuid:c6972648-ddec-4267-aca7-5e14c25dd24d\"\n",
     "if not os.path.exists(\"Integrated_Lake_Ice_Regime_Classification.json\"):\n",
-    "    subprocess.run([\"gsutil\", \"-q\", \"cp\", f\"{_BASELINE_GCS}/Integrated_Lake_Ice_Regime_Classification.json\", \".\"], check=True)\n",
-    "if not os.path.isdir(\"engram\"):\n",
-    "    subprocess.run([\"gsutil\", \"-m\", \"-q\", \"cp\", \"-r\", f\"{_BASELINE_GCS}/engram\", \".\"], check=True)\n"
+    "    urllib.request.urlretrieve(_ADC + _BERGSTEDT, \"Integrated_Lake_Ice_Regime_Classification.json\")\n"
    ]
   },
   {
@@ -52,10 +76,10 @@
    "id": "49bf4f7c-4c9c-429c-b657-254b6a389177",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T18:45:48.744903Z",
-     "iopub.status.busy": "2026-07-10T18:45:48.744605Z",
-     "iopub.status.idle": "2026-07-10T18:45:49.161729Z",
-     "shell.execute_reply": "2026-07-10T18:45:49.160241Z"
+     "iopub.execute_input": "2026-07-11T00:38:55.159710Z",
+     "iopub.status.busy": "2026-07-11T00:38:55.159380Z",
+     "iopub.status.idle": "2026-07-11T00:38:56.025740Z",
+     "shell.execute_reply": "2026-07-11T00:38:56.024711Z"
     }
    },
    "outputs": [],
@@ -85,10 +109,10 @@
    "id": "2f893feb-e94b-4b02-a0ea-ed1aa8be482f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T18:45:49.165699Z",
-     "iopub.status.busy": "2026-07-10T18:45:49.165345Z",
-     "iopub.status.idle": "2026-07-10T18:45:49.423801Z",
-     "shell.execute_reply": "2026-07-10T18:45:49.422425Z"
+     "iopub.execute_input": "2026-07-11T00:38:56.029983Z",
+     "iopub.status.busy": "2026-07-11T00:38:56.029575Z",
+     "iopub.status.idle": "2026-07-11T00:38:56.481207Z",
+     "shell.execute_reply": "2026-07-11T00:38:56.480188Z"
     }
    },
    "outputs": [],
@@ -109,10 +133,10 @@
    "id": "28db778b-187e-43bd-b04e-95c093458494",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T18:45:49.427431Z",
-     "iopub.status.busy": "2026-07-10T18:45:49.427174Z",
-     "iopub.status.idle": "2026-07-10T18:45:54.845231Z",
-     "shell.execute_reply": "2026-07-10T18:45:54.844218Z"
+     "iopub.execute_input": "2026-07-11T00:38:56.486149Z",
+     "iopub.status.busy": "2026-07-11T00:38:56.485368Z",
+     "iopub.status.idle": "2026-07-11T00:39:05.634732Z",
+     "shell.execute_reply": "2026-07-11T00:39:05.633648Z"
     }
    },
    "outputs": [
@@ -124,22 +148,22 @@
       "\n",
       "--- Diagnostic: Searching directory for shapefiles ---\n",
       "Looked for files matching: 'engram/*.shp'\n",
-      "Found 6 shapefile(s): ['engram/Inigok_lakeIce_regimes_1992_2016.shp', 'engram/FishCreek_lakeIce_regimes_1992_2015.shp', 'engram/Teshekpuk_LakeIce_regimes_1992_2016.shp', 'engram/Umiat_lakeIce_regimes_1992_2016.shp', 'engram/Barrow_lakeIce_regimes_1992_2016.shp', 'engram/Kuparuk_lakeIce_regimes_1992_2015.shp']\n",
-      "\n",
-      "Processing file: Inigok_lakeIce_regimes_1992_2016.shp\n",
-      "  -> RAW COLUMNS FOUND IN FILE: ['ID', 'Area_sq_km', 'Lake_hgt_m', 'INI_wacpID', 'Regime1992', 'prctBFI_92', 'PctHiFI_92', 'Regime1993', 'prctBFI_93', 'PctHiFI_93', 'Regime1994', 'prctBFI_94', 'PctHiFI_94', 'Regime1995', 'prctBFI_95', 'PctHiFI_95', 'Regime1996', 'prctBFI_96', 'PctHiFI_96', 'Regime1998', 'prctBFI_98', 'PctHiFI_98', 'Regime1999', 'prctBFI_99', 'PctHiFI_99', 'Regime2000', 'prctBFI_00', 'PctHiFI_00', 'Regime2001', 'prctBFI_01', 'PctHiFI_01', 'Regime2002', 'prctBFI_02', 'PctHiFI_02', 'Regime2003', 'prctBFI_03', 'PctHiFI_03', 'Regime2004', 'prctBFI_04', 'PctHiFI_04', 'Regime2005', 'prctBFI_05', 'PctHiFI_05', 'Regime2006', 'prctBFI_06', 'PctHiFI_06', 'Regime2007', 'prctBFI_07', 'PctHiFI_07', 'Regime2008', 'prctBFI_08', 'PctHiFI_08', 'Regime2009', 'prctBFI_09', 'PctHiFI_09', 'Regime2010', 'prctBFI_10', 'PctHiFI_10', 'Regme2011', 'prctBFI_11', 'PctHiFI_11', 'Regime2012', 'prctBFI_12', 'PctHiFI_12', 'Regime2013', 'prctBFI_13', 'PctHiFI_13', 'Regime2014', 'prctBFI_14', 'PctHiFI_14', 'Reg15apr20', 'prctBFI_15', 'PctHiFI_15', 'Regime2016', 'prctBFI_16', 'PctHiFI_16', 'count_FI', 'count_year', 'prcntYrsFI', 'class', 'note', 'geometry']\n",
-      "  -> SUCCESS: Found classification column. Adding file layer.\n"
+      "Found 6 shapefile(s): ['engram/Inigok_lakeIce_regimes_1992_2016.shp', 'engram/FishCreek_lakeIce_regimes_1992_2015.shp', 'engram/Teshekpuk_lakeIce_regimes_1992_2016.shp', 'engram/Umiat_lakeIce_regimes_1992_2016.shp', 'engram/Barrow_lakeIce_regimes_1992_2016.shp', 'engram/Kuparuk_lakeIce_regimes_1992_2015.shp']\n",
+      "\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Processing file: Inigok_lakeIce_regimes_1992_2016.shp\n",
+      "  -> RAW COLUMNS FOUND IN FILE: ['ID', 'Area_sq_km', 'Lake_hgt_m', 'INI_wacpID', 'Regime1992', 'prctBFI_92', 'PctHiFI_92', 'Regime1993', 'prctBFI_93', 'PctHiFI_93', 'Regime1994', 'prctBFI_94', 'PctHiFI_94', 'Regime1995', 'prctBFI_95', 'PctHiFI_95', 'Regime1996', 'prctBFI_96', 'PctHiFI_96', 'Regime1998', 'prctBFI_98', 'PctHiFI_98', 'Regime1999', 'prctBFI_99', 'PctHiFI_99', 'Regime2000', 'prctBFI_00', 'PctHiFI_00', 'Regime2001', 'prctBFI_01', 'PctHiFI_01', 'Regime2002', 'prctBFI_02', 'PctHiFI_02', 'Regime2003', 'prctBFI_03', 'PctHiFI_03', 'Regime2004', 'prctBFI_04', 'PctHiFI_04', 'Regime2005', 'prctBFI_05', 'PctHiFI_05', 'Regime2006', 'prctBFI_06', 'PctHiFI_06', 'Regime2007', 'prctBFI_07', 'PctHiFI_07', 'Regime2008', 'prctBFI_08', 'PctHiFI_08', 'Regime2009', 'prctBFI_09', 'PctHiFI_09', 'Regime2010', 'prctBFI_10', 'PctHiFI_10', 'Regme2011', 'prctBFI_11', 'PctHiFI_11', 'Regime2012', 'prctBFI_12', 'PctHiFI_12', 'Regime2013', 'prctBFI_13', 'PctHiFI_13', 'Regime2014', 'prctBFI_14', 'PctHiFI_14', 'Reg15apr20', 'prctBFI_15', 'PctHiFI_15', 'Regime2016', 'prctBFI_16', 'PctHiFI_16', 'count_FI', 'count_year', 'prcntYrsFI', 'class', 'note', 'geometry']\n",
+      "  -> SUCCESS: Found classification column. Adding file layer.\n",
       "Processing file: FishCreek_lakeIce_regimes_1992_2015.shp\n",
       "  -> RAW COLUMNS FOUND IN FILE: ['ID', 'Area_sq_km', 'Lake_hgt_m', 'WACP_ID', 'Regime1992', 'prctBFI_92', 'PctHiFI_92', 'Regime1993', 'prctBFI_93', 'PctHiFI_93', 'Regime1994', 'prctBFI_94', 'PctHiFI_94', 'Regime1995', 'prctBFI_95', 'PctHiFI_95', 'Regime1996', 'prctBFI_96', 'PctHiFI_96', 'Regime1997', 'prctBFI_97', 'PctHiFI_97', 'Regime1998', 'prctBFI_98', 'PctHiFI_98', 'Regime2000', 'prctBFI_00', 'PctHiFI_00', 'Regime2001', 'prctBFI_01', 'PctHiFI_01', 'Regime2002', 'prctBFI_02', 'PctHiFI_02', 'Regime2003', 'prctBFI_03', 'PctHiFI_03', 'Regime2004', 'prctBFI_04', 'PctHiFI_04', 'Regime2005', 'prctBFI_05', 'PctHiFI_05', 'Regime2006', 'prctBFI_06', 'PctHiFI_06', 'Regime2007', 'prctBFI_07', 'PctHiFI_07', 'Regime2008', 'prctBFI_08', 'PctHiFI_08', 'Regime2009', 'prctBFI_09', 'PctHiFI_09', 'Regime2010', 'prctBFI_10', 'PctHiFI_10', 'Regime2011', 'prctBFI_11', 'PctHiFI_11', 'Regime2012', 'prctBFI_12', 'PctHiFI_12', 'Regime2013', 'prctBFI_13', 'PctHiFI_13', 'Regime2014', 'prctBFI_14', 'PctHiFI_14', 'Reg15Apr22', 'prctBFI_15', 'PctHiFI_15', 'count_FI', 'count_year', 'prcntYrsFI', 'class', 'Note', 'geometry']\n",
       "  -> SUCCESS: Found classification column. Adding file layer.\n",
-      "Processing file: Teshekpuk_LakeIce_regimes_1992_2016.shp\n",
-      "  -> RAW COLUMNS FOUND IN FILE: ['ID', 'Area_sq_km', 'Lake_hgt_m', 'TES_wacpID', 'F_AREA', 'Regime1992', 'prctBFI_92', 'PctHiFI_92', 'Regime1993', 'prctBFI_93', 'PctHiFI_93', 'Regime1994', 'prctBFI_94', 'PctHiFI_94', 'Regime1995', 'prctBFI_95', 'PctHiFI_95', 'Regime1996', 'prctBFI_96', 'PctHiFI_96', 'Regime1997', 'prctBFI_97', 'PctHiFI_97', 'Regime1998', 'prctBFI_98', 'PctHiFI_98', 'Regime1999', 'prctBFI_99', 'PctHiFI_99', 'Regime2000', 'prctBFI_00', 'PctHiFI_00', 'Regime2001', 'prctBFI_01', 'PctHiFI_01', 'Regime2002', 'prctBFI_02', 'PctHiFI_02', 'Regime2003', 'prctBFI_03', 'PctHiFI_03', 'Regime2004', 'prctBFI_04', 'PctHiFI_04', 'Regime2005', 'prctBFI_05', 'PctHiFI_05', 'Rgim_e2_06', 'prctBFI_06', 'PctHiFI_06', 'Regime2007', 'prctBFI_07', 'PctHiFI_07', 'Reg08Apr20', 'prctBFI_08', 'PctHiFI_08', 'Regime2009', 'prctBFI_09', 'PctHiFI_09', 'Regime2010', 'prctBFI_10', 'PctHiFI_10', 'Regime2011', 'prctBFI_11', 'PctHiFI_11', 'Regime2012', 'prctBFI_12', 'PctHiFI_12', 'Regime2013', 'prctBFI_13', 'PctHiFI_13', 'Regime2014', 'prctBFI_14', 'PctHiFI_14', 'Regime2015', 'prctBFI_15', 'PctHiFI_15', 'Regime2016', 'prctBFI_16', 'PctHiFI_16', 'count_FI', 'count_year', 'prcntyrsFI', 'Class', 'note', 'geometry']\n",
+      "Processing file: Teshekpuk_lakeIce_regimes_1992_2016.shp\n",
+      "  -> RAW COLUMNS FOUND IN FILE: ['ID', 'Area_sq_km', 'Lake_hgt_m', 'TES_wacpID', 'F_AREA', 'Regime1992', 'prctBFI_92', 'PctHiFI_92', 'Regime1993', 'prctBFI_93', 'PctHiFI_93', 'Regime1994', 'prctBFI_94', 'PctHiFI_94', 'Regime1995', 'prctBFI_95', 'PctHiFI_95', 'Regime1996', 'prctBFI_96', 'PctHiFI_96', 'Regime1997', 'prctBFI_97', 'PctHiFI_97', 'Regime1998', 'prctBFI_98', 'PctHiFI_98', 'Regime1999', 'prctBFI_99', 'PctHiFI_99', 'Regime2000', 'prctBFI_00', 'PctHiFI_00', 'Regime2001', 'prctBFI_01', 'PctHiFI_01', 'Regime2002', 'prctBFI_02', 'PctHiFI_02', 'Regime2003', 'prctBFI_03', 'PctHiFI_03', 'Regime2004', 'prctBFI_04', 'PctHiFI_04', 'Regime2005', 'prctBFI_05', 'PctHiFI_05', 'Rgim_e2_06', 'prctBFI_06', 'PctHiFI_06', 'Regime2007', 'prctBFI_07', 'PctHiFI_07', 'Reg08Apr20', 'prctBFI_08', 'PctHiFI_08', 'Regime2009', 'prctBFI_09', 'PctHiFI_09', 'Regime2010', 'prctBFI_10', 'PctHiFI_10', 'Regime2011', 'prctBFI_11', 'PctHiFI_11', 'Regime2012', 'prctBFI_12', 'PctHiFI_12', 'Regime2013', 'prctBFI_13', 'PctHiFI_13', 'Regime2014', 'prctBFI_14', 'PctHiFI_14', 'Regime2015', 'prctBFI_15', 'PctHiFI_15', 'Regime2016', 'prctBFI_16', 'PctHiFI_16', 'count_FI', 'count_year', 'prcntyrsFI', 'Class', 'TES_wacp_1', 'note', 'geometry']\n",
       "  -> SUCCESS: Found classification column. Adding file layer.\n"
      ]
     },
@@ -152,7 +176,13 @@
       "  -> SUCCESS: Found classification column. Adding file layer.\n",
       "Processing file: Barrow_lakeIce_regimes_1992_2016.shp\n",
       "  -> RAW COLUMNS FOUND IN FILE: ['ID', 'Area_sq_km', 'Lake_hgt_m', 'BRW_wacpID', 'Regime1992', 'prctBFI_92', 'PctHiFI_92', 'Regime1993', 'prctBFI_93', 'PctHiFI_93', 'Regime1994', 'prctBFI_94', 'PctHiFI_94', 'Regime1995', 'prctBFI_95', 'PctHiFI_95', 'Regime1996', 'prctBFI_96', 'PctHiFI_96', 'Regime1997', 'prctBFI_97', 'PctHiFI_97', 'Regime1998', 'prctBFI_98', 'PctHiFI_98', 'Regime1999', 'prctBFI_99', 'PctHiFI_99', 'Regime2000', 'prctBFI_00', 'PctHiFI_00', 'Regime2001', 'prctBFI_01', 'PctHiFI_01', 'Regime2002', 'prctBFI_02', 'PctHiFI_02', 'Regime2003', 'prctBFI_03', 'PctHiFI_03', 'Regime2004', 'prctBFI_04', 'PctHiFI_04', 'Regime2005', 'prctBFI_05', 'PctHiFI_05', 'Regime2006', 'prctBFI_06', 'PctHiFI_06', 'Regime2007', 'prctBFI_07', 'PctHiFI_07', 'Regime2008', 'prctBFI_08', 'PctHiFI_08', 'Regime2009', 'prctBFI_09', 'PctHiFI_09', 'Regime2010', 'prctBFI_10', 'PctHiFI_10', 'Regm2011e2', 'prctBFI_11', 'PctHiFI_11', 'Regime2012', 'prctBFI_12', 'PctHiFI_12', 'Regime2013', 'prctBFI_13', 'PctHiFI_13', 'Regime2014', 'prctBFI_14', 'PctHiFI_14', 'Reg15apr20', 'prctBFI_15', 'PctHiFI_15', 'Regime2016', 'prctBFI_16', 'PctHiFI_16', 'count_FI', 'count_year', 'prcntyrsFI', 'class', 'note', 'geometry']\n",
-      "  -> SUCCESS: Found classification column. Adding file layer.\n",
+      "  -> SUCCESS: Found classification column. Adding file layer.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Processing file: Kuparuk_lakeIce_regimes_1992_2015.shp\n",
       "  -> RAW COLUMNS FOUND IN FILE: ['Area_sqkm', 'Kuparuk_ID', 'Regime1992', 'prctBFI_92', 'PctHiFI_92', 'Regime1993', 'prctBFI_93', 'PctHiFI_93', 'Regime1994', 'prctBFI_94', 'PctHiFI_94', 'Regime1995', 'prctBFI_95', 'PctHiFI_95', 'Regime1996', 'prctBFI_96', 'PctHiFI_96', 'Regime1997', 'prctBFI_97', 'PctHiFI_97', 'Regime1998', 'prctBFI_98', 'PctHiFI_98', 'Reg99r1_s5', 'prctBFI_99', 'PctHiFI_99', 'Regime2000', 'prctBFI_00', 'PctHiFI_00', 'Regime2001', 'prctBFI_01', 'PctHiFI_01', 'Regime2002', 'prctBFI_02', 'PctHiFI_02', 'Regime2003', 'prctBFI_03', 'PctHiFI_03', 'Regime2004', 'prctBFI_04', 'PctHiFI_04', 'Regime2005', 'prctBFI_05', 'PctHiFI_05', 'Regime2006', 'prctBFI_06', 'PctHiFI_06', 'Regime2007', 'prctBFI_07', 'PctHiFI_07', 'Regime2008', 'prctBFI_08', 'PctHiFI_08', 'Regime2009', 'prctBFI_09', 'PctHiFI_09', 'Regime2010', 'prctBFI_10', 'PctHiFI_10', 'Reg2011_e2', 'prctBFI_11', 'PctHiFI_11', 'Regime2012', 'prctBFI_12', 'PctHiFI_12', 'Regime2013', 'prctBFI_13', 'PctHiFI_13', 'Regime2014', 'prctBFI_14', 'PctHiFI_14', 'Reg15Apr22', 'prctBFI_15', 'PctHiFI_15', 'count_FI', 'count_year', 'prcntyrsFI', 'class', 'note', 'geometry']\n",
       "  -> SUCCESS: Found classification column. Adding file layer.\n",
@@ -305,10 +335,10 @@
    "id": "19e03b9f-845b-4a0b-b08d-2cf009fe6dc6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T18:45:54.848276Z",
-     "iopub.status.busy": "2026-07-10T18:45:54.847859Z",
-     "iopub.status.idle": "2026-07-10T18:45:54.938220Z",
-     "shell.execute_reply": "2026-07-10T18:45:54.937064Z"
+     "iopub.execute_input": "2026-07-11T00:39:05.638851Z",
+     "iopub.status.busy": "2026-07-11T00:39:05.638339Z",
+     "iopub.status.idle": "2026-07-11T00:39:05.753790Z",
+     "shell.execute_reply": "2026-07-11T00:39:05.752925Z"
     }
    },
    "outputs": [
@@ -349,10 +379,10 @@
    "id": "1d40d404-cec9-4474-a232-5204956eb92d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T18:45:54.942683Z",
-     "iopub.status.busy": "2026-07-10T18:45:54.942309Z",
-     "iopub.status.idle": "2026-07-10T18:45:56.743729Z",
-     "shell.execute_reply": "2026-07-10T18:45:56.742674Z"
+     "iopub.execute_input": "2026-07-11T00:39:05.758101Z",
+     "iopub.status.busy": "2026-07-11T00:39:05.757745Z",
+     "iopub.status.idle": "2026-07-11T00:39:08.305645Z",
+     "shell.execute_reply": "2026-07-11T00:39:08.304588Z"
     }
    },
    "outputs": [

--- a/README.md
+++ b/README.md
@@ -25,12 +25,33 @@ spatial / morphometric analysis and accumulated-degree-day comparison, and the T
 methane companion analysis. Each notebook lists its Python dependencies and reads inputs
 from Google Cloud Storage buckets hosted through Washington University in St. Louis.
 
+Two additional analyses contributed by A. L. Nguyen live in `BedfastFloatingAnalysis/`
+(comparison of the detected phenology against published bedfast/floating ice-regime
+classifications) and `NoPhenologyAnalysis/` (spatial distribution and population
+comparison of lakes with no detected phenology). Their large third-party baseline
+inputs are not stored in this repository; the notebooks download them at runtime from
+the Arctic Data Center (see Data and code availability).
+
 ## Data and code availability
 
 Processed ice-phenology data and analysis code are archived on Zenodo (badge above,
 which resolves to the persistent concept DOI). Source data: Sentinel-1/2 via Google
 Earth Engine; ERA5 via the Copernicus Climate Data Store / ARCO-ERA5; ALPOD lake
 polygons via the ORNL DAAC (doi:10.3334/ORNLDAAC/2399).
+
+The bedfast/floating analysis draws on two third-party lake-ice-regime datasets, both
+dedicated to the public domain (CC0) and downloaded at runtime from the Arctic Data
+Center rather than stored in this repository:
+
+- Engram, M. (2018). *Floating and bedfast lake ice regimes across Arctic Alaska using
+  space-borne SAR imagery from 1992–2016.* Arctic Data Center. doi:10.18739/A2CJ87K8H.
+  (Associated publication: Engram et al., 2018, *Remote Sensing of Environment* 209,
+  660–676, doi:10.1016/j.rse.2018.02.022.)
+- Bergstedt, H., and Jones, B. M. (2025). *Integrated field and synthetic aperture
+  radar-based dataset for Arctic lake ice and under-ice water salinity classification,
+  northern Alaska, 2024.* Arctic Data Center. doi:10.18739/A25M6288G. (Associated
+  publication: Bergstedt et al., 2026, *Water Resources Research* 62(3), e2025WR040504,
+  doi:10.1029/2025WR040504.)
 
 ## License
 


### PR DESCRIPTION
The two additional-analysis notebooks previously carried ~168 MB of baseline data in-tree. This change removes that entirely: the bedfast/floating ice-regime datasets are downloaded at runtime from the Arctic Data Center, where they live as public-domain (CC0) deposits.

- **Engram (2018)** regime shapefiles — doi:10.18739/A2CJ87K8H
- **Bergstedt & Jones (2025)** integrated classification — doi:10.18739/A25M6288G

Both DOIs and their associated papers are now documented in the README. The `BedfastFloatingIceAnalysis` notebook fetches only the six North Slope site zips it uses plus the classification GeoJSON, caches them locally (gitignored), and reads the phenology table from the repo root. `NoPhenologyAnalysis` reads ALPOD from the project bucket as in notebook 01.

Verified: the notebook executes end-to-end against a fresh Arctic Data Center fetch (7,419 baseline entries → 13,596 combined → 6,797 lakes matched), producing an identical figure.
