### PR TITLE
Add Eliza Ross ORCID to Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -21,7 +21,8 @@
     },
     {
       "name": "Ross, Eliza",
-      "affiliation": "Department of Earth, Environmental, and Planetary Sciences, Washington University in St. Louis, St. Louis, MO 63130, USA"
+      "affiliation": "Department of Earth, Environmental, and Planetary Sciences, Washington University in St. Louis, St. Louis, MO 63130, USA",
+      "orcid": "0009-0003-3081-6035"
     },
     {
       "name": "Bradley, Alexander S.",


### PR DESCRIPTION
Adds Eliza Ross's ORCID (0009-0003-3081-6035) to the .zenodo.json creators list.